### PR TITLE
chore: Fix network_info call

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Make sure your `.bashrc` contains the following environment variables -
 ```
 export GRPC_SSL_CIPHER_SUITES='HIGH+ECDSA'
 export LNSERVICE_LND_DATADIR='~/.lnd/'
+export LNSERVICE_SECRET_KEY='1m5ecret4F'
 ```
 
 **Make sure to `$ source ~/.bashrc` in the window you are running the service from**
@@ -41,6 +42,7 @@ Make sure your `.bash_profile` contains the following environment variables -
 ```
 export GRPC_SSL_CIPHER_SUITES='HIGH+ECDSA'
 export LNSERVICE_LND_DATADIR="$(home)/Library/Application Support/Lnd/"
+export LNSERVICE_SECRET_KEY='1m5ecret4F'
 ```
 
 **Make sure to `$ source ~/.bash_profile` in the window you are running the service from**
@@ -50,6 +52,29 @@ export LNSERVICE_LND_DATADIR="$(home)/Library/Application Support/Lnd/"
 ```
 $ npm start
 ```
+
+### Making requests to ln-service
+
+`ln-service` uses Basic Authentication currently.  Make sure that the request has an authorization header that contains Base64 encoded credentials.
+
+Basic example of an authorization header -
+
+```
+Authorization: Basic {{TOKEN_GOES_HERE_WITHOUT_BRACES}}
+```
+
+To generate the Base64 encoded credentials in Chrome for example in the console you can -
+
+```
+> let username = 'test';
+> let password = '1m5secret4F';
+> btoa(`${username}:${password}`);
+// dGVzdDoxbTVlY3JldDRG
+```
+
+And then set the value of the Authorization header to the returned value `dGVzdDoxbTVlY3JldDRG`.
+
+And copy the result as the token in the above example
 
 ### Running the tests
 

--- a/lightning/get_network_info.js
+++ b/lightning/get_network_info.js
@@ -1,7 +1,6 @@
 const {isNumber} = require('lodash');
 const {isString} = require('lodash');
-
-const {rowTypes} = require('./../lightning');
+const rowTypes = require('./conf/row_types');
 
 const decBase = 10;
 

--- a/server.js
+++ b/server.js
@@ -86,4 +86,3 @@ subscribeToTransactions({lnd, wss});
 if (process.env.NODE_ENV !== 'production') {
   walnut.check(require('./package'));
 }
-


### PR DESCRIPTION
Adds basic auth info to README.md as well (I know you are switching it but for now it's valid)

I'll try to lump more changes in next time, so not to spam with GitHub notifications, going to finish up the lnd-gui Browser client I'm working on fully before PRing again.