### PR TITLE
Add ability to specify local_amt to open channel with

### DIFF
--- a/lightning/open_channel.js
+++ b/lightning/open_channel.js
@@ -6,6 +6,7 @@ const {returnResult} = require('./../async-util');
 const channelLimit = require('./conf/lnd').channel_limit_tokens;
 
 const staticFee = 1e3;
+const minimumChannelSize = 20000;
 
 /** Open a new channel.
 
@@ -24,7 +25,8 @@ module.exports = (args, cbk) => {
       const balance = getChainBalance.chain_balance;
       const limit = channelLimit;
 
-      const channelAmount = balance > limit ? limit : balance;
+      const maxAvailable = balance > limit ? limit : balance;
+      const channelAmount = args.local_amt ? args.local_amt : maxAvailable;
 
       const open = args.lnd.openChannel({
         local_funding_amount: channelAmount - staticFee,

--- a/routers/channels.js
+++ b/routers/channels.js
@@ -22,17 +22,17 @@ module.exports = ({lnd}) => {
     return closeChannel({lnd, id: params.id}, returnJson({res}));
   });
 
-  // 
+  //
   router.get('/', (_, res) => getChannels({lnd}, returnJson({res})));
 
   router.post('/', ({body}, res, next) => {
     return openChannel({
       lnd,
       partner_public_key: body.partner_public_key,
+      local_amt: body.local_amt,
     },
     returnJson({res}));
   });
 
   return router;
 };
-


### PR DESCRIPTION
Adds ability to specify `local_amt` when opening a channel, leaves in place the fallback of using the max balance if one is not specified for backwards compatbility