### PR TITLE
destructure log as well

### DIFF
--- a/routers/crypto.js
+++ b/routers/crypto.js
@@ -13,7 +13,7 @@ const Router = require('./router');
   @returns
   <Router Object>
 */
-module.exports = ({lnd}) => {
+module.exports = ({lnd, log}) => {
   const router = Router({});
 
   router.post('/sign', ({body}, res) => {


### PR DESCRIPTION
Calls fail for missing `log` in the arguments