### PR TITLE
Fix add peers route

### DIFF
--- a/routers/peers.js
+++ b/routers/peers.js
@@ -30,9 +30,12 @@ module.exports = ({lnd, log}) => {
     }
   */
   router.post('/', ({body}, res) => {
+    const host = body.host;
+    const port = body.port || 9735;
+
     return addPeer({
       lnd,
-      host: body.host,
+      socket: `${host}:${port}`,
       public_key: body.public_key,
     },
     returnJson({log, res}));


### PR DESCRIPTION
Allow the route to receive `host` and `port` and combine them in the route.  Fixes broken route.