### PR TITLE
Allow paying invoices with no amount

### DIFF
--- a/lightning/pay.js
+++ b/lightning/pay.js
@@ -34,6 +34,7 @@ const decBase = 10;
       }]
     }
     [request]: <BOLT 11 Payment Request String>
+    [tokens]: <Total Tokens To Pay Number>
     [wss]: [<Web Socket Server Object>]
   }
 
@@ -57,7 +58,7 @@ const decBase = 10;
     type: <Type String>
   }
 */
-module.exports = ({fee, lnd, log, path, request, wss}, cbk) => {
+module.exports = ({fee, lnd, log, path, request, tokens, wss}, cbk) => {
   if (!path && !request) {
     return cbk([400, 'ExpectedPathOrRequestToPay']);
   }
@@ -76,7 +77,7 @@ module.exports = ({fee, lnd, log, path, request, wss}, cbk) => {
 
   // Exit early when the invoice is defined
   if (!path) {
-    return payPaymentRequest({fee, lnd, log, request, wss}, cbk);
+    return payPaymentRequest({fee, lnd, log, request, tokens, wss}, cbk);
   }
 
   lnd.sendToRouteSync({

--- a/lightning/pay_payment_request.js
+++ b/lightning/pay_payment_request.js
@@ -12,6 +12,7 @@ const decBase = 10;
     lnd: <LND GRPC API Object>
     [log]: <Log Function> // Required if wss is set
     request: <BOLT 11 Payment Request String>
+    [tokens]: <Total Tokens To Pay Number>
     [wss]: [<Web Socket Server Object>]
   }
 
@@ -35,7 +36,7 @@ const decBase = 10;
     type: <Row Type String>
   }
 */
-module.exports = ({fee, lnd, log, request, wss}, cbk) => {
+module.exports = ({fee, lnd, log, request, tokens, wss}, cbk) => {
   if (!lnd || !lnd.sendPaymentSync) {
     return cbk([400, 'ExpectedLndForPayingPaymentRequest']);
   }
@@ -58,6 +59,9 @@ module.exports = ({fee, lnd, log, request, wss}, cbk) => {
     params.fee_limit = {fixed: fee};
   }
 
+  if (!!tokens) {
+    params.amt = tokens.toString()
+  }
   return lnd.sendPaymentSync(params, (err, res) => {
     if (!!err) {
       return cbk([503, 'SendPaymentErr', err, res]);

--- a/pay.js
+++ b/pay.js
@@ -28,6 +28,7 @@ const {pay} = require('./');
       }]
     }
     [request]: <BOLT 11 Payment Request String>
+    [tokens]: <Total Tokens To Pay Number>
     [wss]: [<Web Socket Server Object>]
   }
 


### PR DESCRIPTION
Currently, if I create an invoice with no amount, it's not possible to pay the invoice by passing a custom amount using `ln-service/pay`. I've added an optional `tokens` param to the pay function that will get passed to `pay_payment_request.js` when no `path` is specified. 