### PR TITLE
Allow macaroon to be specified in hexadecimal

### DIFF
--- a/lightning/lightning_daemon.js
+++ b/lightning/lightning_daemon.js
@@ -70,7 +70,7 @@ module.exports = ({cert, macaroon, service, socket}) => {
 
   switch (serviceType) {
   case defaultServiceType:
-    const macaroonData = Buffer.from(macaroon, 'base64').toString('hex');
+    const macaroonData = /^([0-9A-Fa-f]{2})+$/g.test(macaroon) ? macaroon : Buffer.from(macaroon, 'base64').toString('hex');
 
     const macCreds = grpc.credentials.createFromMetadataGenerator((_, cbk) => {
       const metadata = new grpc.Metadata();


### PR DESCRIPTION
BTCPay Server show the macaroon as hex string. So users need to convert their hex to base64 through converter, while your code internally manipulate macaroonData as an hex string!

This change will allow support of macaroon in hexadecimal.