### PR TITLE
changing README to make it a little more copy and paste friendly

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,12 +139,20 @@ instead of setting environment variables.
 
 Environment variables:
 
-    export GRPC_SSL_CIPHER_SUITES='HIGH+ECDSA'
+    export GRPC_SSL_CIPHER_SUITES="HIGH+ECDSA"
     export LNSERVICE_CHAIN="bitcoin" // or litecoin
-    export LNSERVICE_LND_DIR='~/.lnd/'
+    export LNSERVICE_LND_DIR="/PATH/TO/.lnd/"
     export LNSERVICE_NETWORK="testnet" // or mainnet
-    export LNSERVICE_SECRET_KEY=REPLACE!WITH!SECRET!KEY!
+    export LNSERVICE_SECRET_KEY="REPLACE!WITH!SECRET!KEY!"
 
+.env file:
+    
+    GRPC_SSL_CIPHER_SUITES='HIGH+ECDSA'
+    LNSERVICE_CHAIN='bitcoin'
+    LNSERVICE_LND_DIR='/PATH/TO/.lnd/'
+    LNSERVICE_NETWORK='testnet'
+    LNSERVICE_SECRET_KEY='REPLACE!WITH!SECRET!KEY!'
+    
 Setting environment variables in Linux:
 
 - Edit `.bashrc` or `~/.profile`


### PR DESCRIPTION
I ran into some challenges getting this set up and it ended up being because of copying and pasting code form the readme to a `.env` file. Just tweaking it a bit in case others are having the same issue.