### PR TITLE
Update verify_message.js

### DIFF
--- a/lightning/verify_message.js
+++ b/lightning/verify_message.js
@@ -48,10 +48,10 @@ module.exports = ({lnd, message, signature}, cbk) => {
           }
 
           if (!res.valid) {
-            return cbk(null, {});
+            return cbk(null, {signed_by: res.pubkey, valid:res.valid});
           }
 
-          return cbk(null, {signed_by: res.pubkey});
+          return cbk(null, {signed_by: res.pubkey, valid:res.valid});
         });
       }],
     },


### PR DESCRIPTION
This pull request fixes #93

Return the valid parameter within the body to allow mobile/private nodes to verify messages to use this package for efficient auth services using lightning ⚡️ 