### PR TITLE
avoid big int literals

### DIFF
--- a/lightning/get_invoice.js
+++ b/lightning/get_invoice.js
@@ -4,7 +4,7 @@ const {returnResult} = require('asyncjs-util');
 
 const decBase = 10;
 const msPerSec = 1e3;
-const mtokensPerToken = 1000n;
+const mtokensPerToken = BigInt('1000');
 
 /** Lookup a channel invoice.
 

--- a/lightning/get_invoices.js
+++ b/lightning/get_invoices.js
@@ -16,7 +16,7 @@ const defaultLimit = 100;
 const {isArray} = Array;
 const lastPageFirstIndexOffset = 1;
 const msPerSec = 1e3;
-const mtokensPerToken = 1000n;
+const mtokensPerToken = BigInt('1000');
 const {parse} = JSON;
 const {stringify} = JSON;
 

--- a/router/get_payment_odds.js
+++ b/router/get_payment_odds.js
@@ -94,9 +94,9 @@ module.exports = ({hops, lnd}, cbk) => {
         });
 
         const totalDenominator = odds.slice(1)
-          .reduce((sum, n) => sum * oddsDenominator, 1n);
+          .reduce((sum, n) => sum * oddsDenominator, BigInt('1'));
 
-        const totalOdds = odds.reduce((sum, n) => sum * BigInt(n), 1n);
+        const totalOdds = odds.reduce((sum, n) => sum * BigInt(n), BigInt('1'));
 
         const successOdds = (totalOdds / totalDenominator).toString();
 


### PR DESCRIPTION
BigInt literal notation doesn't have wide support yet and will break in certain situations (such as webpack builds). Using `BigInt()` global instead fixes this.