### PR TITLE
use @ln-zap/proto-loader instead of @grpc/proto-loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -2369,7 +2369,7 @@ LND 0.8.2 and below do not support `cooperative_close_address`
 Example:
 
 ```node
-const {openChannel} = require('ln-service');  
+const {openChannel} = require('ln-service');
 const publicKey = 'publicKeyHexString';
 const tokens = 1000000;
 await openChannel({lnd, local_tokens: tokens, partner_public_key: publicKey});
@@ -4689,13 +4689,13 @@ Environment variables:
     export LNSERVICE_SECRET_KEY="REPLACE!WITH!SECRET!KEY!"
 
 .env file:
-    
+
     GRPC_SSL_CIPHER_SUITES='HIGH+ECDSA'
     LNSERVICE_CHAIN='bitcoin'
     LNSERVICE_LND_DIR='/PATH/TO/.lnd/'
     LNSERVICE_NETWORK='testnet'
     LNSERVICE_SECRET_KEY='REPLACE!WITH!SECRET!KEY!'
-    
+
 Setting environment variables in Linux:
 
 - Edit `.bashrc` or `~/.profile`

--- a/grpc/authenticated_lnd_grpc.js
+++ b/grpc/authenticated_lnd_grpc.js
@@ -1,7 +1,7 @@
 const {join} = require('path');
 
 const grpc = require('grpc');
-const {loadSync} = require('@grpc/proto-loader');
+const {loadSync} = require('@ln-zap/proto-loader');
 
 const {defaultSocket} = require('./conf/grpc_services');
 const grpcCredentials = require('./grpc_credentials');

--- a/grpc/unauthenticated_lnd_grpc.js
+++ b/grpc/unauthenticated_lnd_grpc.js
@@ -1,7 +1,7 @@
 const {join} = require('path');
 
 const grpc = require('grpc');
-const {loadSync} = require('@grpc/proto-loader');
+const {loadSync} = require('@ln-zap/proto-loader');
 
 const grpcSsl = require('./grpc_ssl');
 const {grpcSslCipherSuites} = require('./conf/grpc_services');

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   },
   "dependencies": {
     "@datastructures-js/priority-queue": "1.0.2",
-    "@grpc/proto-loader": "0.5.3",
+    "@ln-zap/proto-loader": "^0.5.1",
     "async": "3.1.0",
     "asyncjs-util": "1.1.3",
     "basicauth-middleware": "3.1.0",


### PR DESCRIPTION
The @grpc/proto-loader module that is currently used causes a problem when going through a build with webpack. The error returned when ln-service is built is: 

`The "path" argument must be of type string. Received type number`

This can be an indication of node's `path` module operating on a dynamic import (since one of the arguments isn't a string when being analyzed by webpack). ln-zap appears to have a fork of this module that fixes the issue (probably because they are using `proto-loader` in an electron app which needs to be compiled with webpack). This PR replaces the @grpc package w/ Zap's.

Also fixed a typo in the readme.