### PR TITLE
Add [confirmed_index] to getInvoice documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2341,6 +2341,7 @@ Requires `invoices:read` permission
       [chain_address]: <Fallback Chain Address String>
       cltv_delta: <CLTV Delta Number>
       [confirmed_at]: <Settled at ISO 8601 Date String>
+      [confirmed_index]: <Confirmed Index Number>
       created_at: <ISO 8601 Date String>
       description: <Description String>
       [description_hash]: <Description Hash Hex String>


### PR DESCRIPTION
Hi, thanks for this package!

I noticed that the documentation for `getInvoice` is missing this property. It's currently only mentioned in `getInvoices` but it's also returned in `getInvoice`.